### PR TITLE
support Pipe mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,9 @@ var (
 
 	// output directory
 	outDir = ""
+
+	// use command pipe
+	usePipe = false
 )
 
 // newApp returns *cli.App [use testing]
@@ -60,6 +63,11 @@ func newApp() *cli.App {
 			Value:       "",
 			Destination: &outDir,
 		},
+		cli.BoolFlag{
+			Name:        "pipe",
+			Usage:       "input from stdin, output to stdout",
+			Destination: &usePipe,
+		},
 	}
 
 	return app
@@ -71,6 +79,12 @@ func validateFlags(ctx *cli.Context) error {
 	if jobs < 1 {
 		msg := fmt.Sprintf("invalid job thread number [%d]", jobs)
 		return cli.NewExitError(msg, 1)
+	}
+
+	// use pipe mode
+	if usePipe {
+		jobs = 1             // single job
+		hideProgress = false // supress progress bar
 	}
 
 	return nil

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"bytes"
 
+	"image/jpeg"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -185,7 +187,6 @@ func TestSetOutputDirectory(t *testing.T) {
 func TestPipeIO(t *testing.T) {
 	args := []string{"kelp", "--pipe", "jpg"}
 	src := "testdata/dummy_png.tmp"
-	dest := "testdata/dummy_jpg.tmp2"
 
 	r, err := os.Open(src)
 	assert.Nil(t, err)
@@ -202,8 +203,6 @@ func TestPipeIO(t *testing.T) {
 	assert.Nil(t, err)
 
 	// check
-	tmp, err := ioutil.ReadFile(dest)
+	_, err = jpeg.Decode(bytes.NewReader(w.Bytes()))
 	assert.Nil(t, err)
-
-	assert.Equal(t, w.Bytes(), tmp)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"bytes"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -179,4 +180,30 @@ func TestSetOutputDirectory(t *testing.T) {
 
 	defer os.RemoveAll(testdir)
 	testHelperRunApp(t, tests)
+}
+
+func TestPipeIO(t *testing.T) {
+	args := []string{"kelp", "--pipe", "jpg"}
+	src := "testdata/dummy_png.tmp"
+	dest := "testdata/dummy_jpg.tmp2"
+
+	r, err := os.Open(src)
+	assert.Nil(t, err)
+	defer r.Close()
+
+	w := new(bytes.Buffer)
+
+	// pipe execute
+	pipeStdin = r
+	pipeStdout = w
+	app := setupApp()
+
+	err = app.Run(args)
+	assert.Nil(t, err)
+
+	// check
+	tmp, err := ioutil.ReadFile(dest)
+	assert.Nil(t, err)
+
+	assert.Equal(t, w.Bytes(), tmp)
 }


### PR DESCRIPTION
The Pipe mode receives an image from stdin and returns the conversion result to stdout.